### PR TITLE
Fix/SendAdaptiveCardAction fehlerhaft 

### DIFF
--- a/lib/neo-test-functions.js
+++ b/lib/neo-test-functions.js
@@ -66,8 +66,8 @@
   function getAcData(path, particle) {
     const adaptiveCardActionIndex = getAcIndex(path)
     // Construct path to a nested AC object
-    const actionDataPath = `particle.response.content[${adaptiveCardActionIndex}].${path.join('.')}`
-    const actionData = eval(actionDataPath)
+    const actionDataPath = `response.content[${adaptiveCardActionIndex}].${path.join('.')}`
+    const actionData = get(particle, actionDataPath)
     return actionData
   }
 
@@ -106,7 +106,6 @@
       const inputs = getKeys(restrictedParticle.response.content, 'Input.')
       inputs.map((input) => {
         const inputData = getAcData(input.path, restrictedParticle)
-        console.log(inputData)
         actionData[`${inputData.id}`] = inputData.value
       })
 
@@ -617,8 +616,8 @@
 
     // Filter/Adapt particle
     // The elem to search start's counting at 1...
-    const path = `particle.response.${typeToAdapt}.slice(${elementToSearch - 1}, ${elementToSearch})`
-    particle.response[typeToAdapt] = eval(path)
+    const path = `response.${typeToAdapt}.slice(${elementToSearch - 1}, ${elementToSearch})`
+    particle.response[typeToAdapt] = get(particle, path)
 
     return particle
   }
@@ -647,6 +646,25 @@
       pm.expect.fail(`${input} is not a valid input of type string or number`)
     })
     return false
+  }
+
+  /**
+   * Gets the value at path of object.
+   * Note: If provided path does not exists inside the object js will generate error.
+   * Source: https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_get
+   * @param {Object} obj to get the value for
+   * @param {String} path to the value
+   * @param {Objec} defaultValue to get
+   * @returns value at path of object
+   */
+  const get = (obj, path, defaultValue = undefined) => {
+    const travel = (regexp) =>
+      String.prototype.split
+        .call(path, regexp)
+        .filter(Boolean)
+        .reduce((res, key) => (res !== null && res !== undefined ? res[key] : res), obj)
+    const result = travel(/[,[\]]+?/) || travel(/[,[\].]+?/)
+    return result === undefined || result === obj ? defaultValue : result
   }
 
   // TODO ADD HERE CUSTOM FUNCTIONS

--- a/lib/neo-test-functions.js
+++ b/lib/neo-test-functions.js
@@ -61,18 +61,13 @@
     return adaptiveCardIndex
   }
 
-  // Construct path to a nested AC object
-  // Uses the AC Index and the path
-  function constructPath(adaptiveCardIndex, path) {
-    return `restrictedParticle.response.content[${adaptiveCardIndex}].${path.join('.')}`
-  }
-
   // Get data nested in an AC
   // Uses the path to the data/object
   function getAcData(path, particle) {
     const restrictedParticle = particle
     const adaptiveCardActionIndex = getAcIndex(path)
-    const actionDataPath = constructPath(adaptiveCardActionIndex, path)
+    // Construct path to a nested AC object
+    const actionDataPath = `restrictedParticle.response.content[${adaptiveCardIndex}].${path.join('.')}`
     const actionData = eval(actionDataPath)
     return actionData
   }

--- a/lib/neo-test-functions.js
+++ b/lib/neo-test-functions.js
@@ -51,22 +51,18 @@
     return particle
   }
 
-  // Get the index of the AC
-  // This is the case with multiple ACs
-  function getAcIndex(path) {
+  // Get data nested in an AC
+  // Uses the path to the data/object
+  function getAcData(path, particle) {
+    // Get the index of the AC
+    // This is the case with multiple ACs
     let adaptiveCardIndex = 0
     if (Number.isInteger(parseInt(path[0]))) {
       adaptiveCardIndex = path.shift()
     }
-    return adaptiveCardIndex
-  }
 
-  // Get data nested in an AC
-  // Uses the path to the data/object
-  function getAcData(path, particle) {
-    const adaptiveCardActionIndex = getAcIndex(path)
     // Construct path to a nested AC object
-    const actionDataPath = `response.content[${adaptiveCardActionIndex}].${path.join('.')}`
+    const actionDataPath = `response.content[${adaptiveCardIndex}].${path.join('.')}`
     const actionData = get(particle, actionDataPath)
     return actionData
   }

--- a/lib/neo-test-functions.js
+++ b/lib/neo-test-functions.js
@@ -63,35 +63,47 @@
    */
   const sendAdaptiveCardAction = async (action = null, { position = null, actionIndex = 0 } = {}) => {
     const restrictedParticle = narrowParticle(position, 'content')
+    const hasAdaptiveCard = restrictedParticle.response.content
+      .map((contentElem) => contentElem['type'])
+      .includes('adaptivecard')
 
     // Form validation: Check, that we have at least one adaptive card
-    if (!restrictedParticle.response.content.map((contentElem) => contentElem['type']).includes('adaptivecard')) {
+    if (!hasAdaptiveCard || !action) {
       pm.test(`Send adaptive card with data for action ${action}`, () => {
-        pm.expect.fail(`No adaptive card found for action ${action}`)
+        pm.expect.fail(`No adaptive card found or no action provided!`)
       })
       return
     }
 
-    // Search for path to action
-    // As default, we take the first value found = actionIndex
-    const { key, path } = getKeys(restrictedParticle.response.content, action, { exact: true })[actionIndex]
+    // Process:
+    // 1. Search path to action object and respective AC if there are more than one
+    // 2. Evaluate value at path(Action contents)
+    // 3. Send actual action with data contents
+    try {
+      // Search for path to action
+      // As default, we take the first value found = actionIndex
+      const { key, path } = getKeys(restrictedParticle.response.content, action, { exact: true })[actionIndex]
+      // Get the index of the AC
+      // This is the case with multiple ACs
+      let adaptiveCardIndex = 0
+      if (Number.isInteger(parseInt(path[0]))) {
+        adaptiveCardIndex = path.shift()
+      }
 
-    // Get the index of the AC
-    let adaptiveCardIndex = 0
-    if (Number.isInteger(parseInt(path[0]))) {
-      adaptiveCardIndex = path.shift()
+      // Construct path to action
+      const dataPath = `restrictedParticle.response.content[${adaptiveCardIndex}].${path.join('.')}`
+      const data = eval(dataPath)
+
+      // Make query
+      particle = await sendAction(action, data)
+      return particle
+    } catch (error) {
+      console.error(error)
+      pm.test(`Send adaptive card with data for action ${action}`, () => {
+        pm.expect.fail(`Action ${action} at action position ${actionIndex} probably not found.\n${error}`)
+      })
+      return
     }
-
-    // TODO this fails, when the path only has one elem. F.ex [0] ??
-    // TODO write safe variant
-    // Construct path to action
-    const dataPath = `restrictedParticle.response.content[${adaptiveCardIndex}].${path.join('.')}`
-
-    const data = eval(dataPath)
-
-    // Make query
-    particle = await sendAction(action, data)
-    return particle
   }
 
   /**

--- a/lib/neo-test-functions.js
+++ b/lib/neo-test-functions.js
@@ -64,10 +64,9 @@
   // Get data nested in an AC
   // Uses the path to the data/object
   function getAcData(path, particle) {
-    const restrictedParticle = particle
     const adaptiveCardActionIndex = getAcIndex(path)
     // Construct path to a nested AC object
-    const actionDataPath = `restrictedParticle.response.content[${adaptiveCardIndex}].${path.join('.')}`
+    const actionDataPath = `restrictedParticle.response.content[${adaptiveCardActionIndex}].${path.join('.')}`
     const actionData = eval(actionDataPath)
     return actionData
   }
@@ -102,12 +101,13 @@
       const actionPath = getKeys(restrictedParticle.response.content, action, { exact: true })[actionIndex].path
       const actionData = getAcData(actionPath, restrictedParticle)
 
-      // 2. Get all Inputs and placeholder from AC and add them to the data to be send
-      // Format: input_id: input_placeholder
+      // 2. Get all Inputs and values from AC and add them to the data to be send
+      // Format: input_id: input_value
       const inputs = getKeys(restrictedParticle.response.content, 'Input.')
       inputs.map((input) => {
         const inputData = getAcData(input.path, restrictedParticle)
-        actionData[`${inputData.id}`] = inputData.placeholder
+        console.log(inputData)
+        actionData[`${inputData.id}`] = inputData.value
       })
 
       // We don't need the action attribute in the data section

--- a/lib/neo-test-functions.js
+++ b/lib/neo-test-functions.js
@@ -612,8 +612,8 @@
 
     // Filter/Adapt particle
     // The elem to search start's counting at 1...
-    const path = `response.${typeToAdapt}.slice(${elementToSearch - 1}, ${elementToSearch})`
-    particle.response[typeToAdapt] = get(particle, path)
+    const objectToAdapt = get(particle, `response.${typeToAdapt}`)
+    particle.response[typeToAdapt] = objectToAdapt.slice(elementToSearch - 1, elementToSearch)
 
     return particle
   }

--- a/lib/neo-test-functions.js
+++ b/lib/neo-test-functions.js
@@ -66,7 +66,7 @@
   function getAcData(path, particle) {
     const adaptiveCardActionIndex = getAcIndex(path)
     // Construct path to a nested AC object
-    const actionDataPath = `restrictedParticle.response.content[${adaptiveCardActionIndex}].${path.join('.')}`
+    const actionDataPath = `particle.response.content[${adaptiveCardActionIndex}].${path.join('.')}`
     const actionData = eval(actionDataPath)
     return actionData
   }

--- a/lib/neo-test-functions.js
+++ b/lib/neo-test-functions.js
@@ -72,13 +72,21 @@
       return
     }
 
-    // Search for action
+    // Search for path to action
+    // As default, we take the first value found = actionIndex
     const { key, path } = getKeys(restrictedParticle.response.content, action, { exact: true })[actionIndex]
+
+    // Get the index of the AC
     let adaptiveCardIndex = 0
     if (Number.isInteger(parseInt(path[0]))) {
       adaptiveCardIndex = path.shift()
     }
+
+    // TODO this fails, when the path only has one elem. F.ex [0] ??
+    // TODO write safe variant
+    // Construct path to action
     const dataPath = `restrictedParticle.response.content[${adaptiveCardIndex}].${path.join('.')}`
+
     const data = eval(dataPath)
 
     // Make query
@@ -272,7 +280,7 @@
     fuzzyDataSearchTest(restrictedParticle.response.content, text, 'text')
   }
 
-  // ------ NEO CONTROLS ------ 
+  // ------ NEO CONTROLS ------
 
   /**
    * Check whether sticky was cleared
@@ -280,7 +288,7 @@
   const triggersStickyClear = () => {
     const { sticky } = particle.response
     pm.test(`Check for cleared sticky value`, () => {
-        pm.expect(sticky).to.be.false
+      pm.expect(sticky).to.be.false
     })
   }
 
@@ -294,9 +302,9 @@
     const restrictedParticle = narrowParticle(position, 'content')
     isContentType('audio.recorder', { particle: restrictedParticle })
     if (target && isValidInput(target)) fuzzyDataSearchTest(restrictedParticle.response.content, target, 'target')
-    if (metadata && isValidInput(metadata)) fuzzyDataSearchTest(restrictedParticle.response.content, metadata, 'metadata')
+    if (metadata && isValidInput(metadata))
+      fuzzyDataSearchTest(restrictedParticle.response.content, metadata, 'metadata')
   }
-
 
   /**
    * Check for camera triggering parameters
@@ -529,7 +537,10 @@
         const escapedString = `${val}`.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
         const searchAsRegEx = new RegExp(`${escapedString}`, 'gi')
         const searchResult = exact ? obj[prop].toString().localeCompare(val) : searchAsRegEx.test(obj[prop].toString())
-        if (searchResult || (Array.isArray(searchResult) && searchResult.length > 0)) {
+
+        const isExactMatch = searchResult === 0
+        const isFuzzySearchMatch = searchResult === true
+        if (isExactMatch || isFuzzySearchMatch) {
           // Fuzzy search
           objects.push({ key: prop, path: newPath })
         }

--- a/lib/neo-test-functions.js
+++ b/lib/neo-test-functions.js
@@ -51,6 +51,32 @@
     return particle
   }
 
+  // Get the index of the AC
+  // This is the case with multiple ACs
+  function getAcIndex(path) {
+    let adaptiveCardIndex = 0
+    if (Number.isInteger(parseInt(path[0]))) {
+      adaptiveCardIndex = path.shift()
+    }
+    return adaptiveCardIndex
+  }
+
+  // Construct path to a nested AC object
+  // Uses the AC Index and the path
+  function constructPath(adaptiveCardIndex, path) {
+    return `restrictedParticle.response.content[${adaptiveCardIndex}].${path.join('.')}`
+  }
+
+  // Get data nested in an AC
+  // Uses the path to the data/object
+  function getAcData(path, particle) {
+    const restrictedParticle = particle
+    const adaptiveCardActionIndex = getAcIndex(path)
+    const actionDataPath = constructPath(adaptiveCardActionIndex, path)
+    const actionData = eval(actionDataPath)
+    return actionData
+  }
+
   /**
    * Send adaptive card action with data attribute
    * Useful f.ex for actions like Button clicks on adaptive cards
@@ -75,27 +101,24 @@
       return
     }
 
-    // Process:
-    // 1. Search path to action object and respective AC if there are more than one
-    // 2. Evaluate value at path(Action contents)
-    // 3. Send actual action with data contents
     try {
-      // Search for path to action
+      // 1. Search path to action object get get action data
       // As default, we take the first value found = actionIndex
-      const { key, path } = getKeys(restrictedParticle.response.content, action, { exact: true })[actionIndex]
-      // Get the index of the AC
-      // This is the case with multiple ACs
-      let adaptiveCardIndex = 0
-      if (Number.isInteger(parseInt(path[0]))) {
-        adaptiveCardIndex = path.shift()
-      }
+      const actionPath = getKeys(restrictedParticle.response.content, action, { exact: true })[actionIndex].path
+      const actionData = getAcData(actionPath, restrictedParticle)
 
-      // Construct path to action
-      const dataPath = `restrictedParticle.response.content[${adaptiveCardIndex}].${path.join('.')}`
-      const data = eval(dataPath)
+      // 2. Get all Inputs and placeholder from AC and add them to the data to be send
+      // Format: input_id: input_placeholder
+      const inputs = getKeys(restrictedParticle.response.content, 'Input.')
+      inputs.map((input) => {
+        const inputData = getAcData(input.path, restrictedParticle)
+        actionData[`${inputData.id}`] = inputData.placeholder
+      })
 
-      // Make query
-      particle = await sendAction(action, data)
+      // We don't need the action attribute in the data section
+      delete actionData['action']
+
+      particle = await sendAction(action, actionData)
       return particle
     } catch (error) {
       console.error(error)
@@ -600,7 +623,7 @@
     // Filter/Adapt particle
     // The elem to search start's counting at 1...
     const path = `particle.response.${typeToAdapt}.slice(${elementToSearch - 1}, ${elementToSearch})`
-    particle.response.content = eval(path)
+    particle.response[typeToAdapt] = eval(path)
 
     return particle
   }


### PR DESCRIPTION
> https://app.asana.com/0/931187879943971/1200206163177944/f

### Changes

- [x] Pass `Input.*` values with the `data` attribute
  - [x] Iterate through all Inputs and populate the action `data` Attribute in the following format: `input_id: input_value`
- [x] Pass `data` Attribute with f.ex messages when sending ACs
- [x] Switch from `eval()` to `get()`-Function
- [x] Misc Refactoring/Fixes

---

Tested in:

1. Smith tests

- Tested with  `flow_testing:ac-flow-testing` on smith: Simply do `/ac_test`. 

```js
    await sendMessage('/ac_test')
    showsAdaptiveCard('action_submit')

    await sendAdaptiveCardAction('action_submit_1')
    showsText('action_submit_1')

    await sendMessage('/ac_test')
    showsAdaptiveCard('action_submit')


    await sendAdaptiveCardAction('action_submit_2')
    showsText('action_submit_2')
```

2. Cypher tests
3. Tests from Sebastian