### PR TITLE
fix(isValidInput): change type check to number

### DIFF
--- a/lib/neo-test-functions.js
+++ b/lib/neo-test-functions.js
@@ -639,7 +639,7 @@
    * @returns {boolean} whether it is valid or not
    */
   const isValidInput = (input) => {
-    if (typeof input === 'string' || typeof input === 'Number') {
+    if (typeof input === 'string' || typeof input === 'number') {
       return true
     }
     pm.test(`Input form validation`, () => {


### PR DESCRIPTION
"Number" is a constructor name. The correct type to be checked is "number".

This fixes an issue where the check of the intent confidence would produce unexpected results during validation